### PR TITLE
Decrease bundle size -- remove source content from source maps

### DIFF
--- a/build.js
+++ b/build.js
@@ -47,6 +47,7 @@ const esbuildConf = (format) => ({
   format: format,
   outdir: `dist/${format}`,
   sourcemap: true,
+  sourcesContent: false,
   treeShaking: true,
   minify: true,
   plugins: [nodeExternalsPlugin(), svgrPlugin(), sassPlugin()],


### PR DESCRIPTION
Decrease bundle size by removing source content from source maps. Bundle size of the dist folder decreased from 4.6M to 2.6M.

The reason the npm package size is so large is because of sourcemaps. There are two options here:

1. Publish no sourcemaps — this decreases dist size to 1.6M
2. Publish sourcemaps but without embedded source content — this decreases dist size to 2.6M

I think (2) is the best option. We want to keep source maps so users can more easily debug, and because we already ship the source in the "src" directory, we don't need the source maps to include the source content a second time. See https://github.com/source-map/source-map-rfc/issues/41 for a longer discussion on the pros / cons of large source maps.