### PR TITLE
Fix misc. typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ The core team will promptly review your Pull Request and either merge it or requ
 
 - All branches should be targeted at `main`.
 - The reference issue number should be include in the branch name.
-- Pull Request titles should be formated as `[Issue #] [Component] Imperative description`. For example, `[#1045] [Button] Add force theme support.`
+- Pull Request titles should be formatted as `[Issue #] [Component] Imperative description`. For example, `[#1045] [Button] Add force theme support.`
 - There should be a description for the reviewer on how the code is structured and what to review.
 - All code should be linted, well-formated, and type-safe (running `yarn prettier`, `yarn lint`, and `yarn typescript`)
 - Any API changes should tag the core team to update documentation.

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -84,7 +84,7 @@ export interface DialogProps {
   inputField?: Array<InputComponent | TextAreaComponent> | InputComponent | TextAreaComponent;
   loading?: boolean;
   level?: 'l0' | 'l1' | 'l2' | 'l3';
-  // if dialog contains non button content otherwise pass in buttom group item and auto-layout
+  // if dialog contains non button content otherwise pass in button group item and auto-layout
   customContent?: boolean;
   isMobile?: boolean;
   disableOffClick?: boolean;


### PR DESCRIPTION
Found via `codespell -q 3 -S ./node_modules`