### PR TITLE
feat: introduce css variables for fonts

### DIFF
--- a/src/components/CodeInput/CodeInput.tsx
+++ b/src/components/CodeInput/CodeInput.tsx
@@ -38,7 +38,7 @@ const CodeInputField = styled.input<{
   }}
 
   // H4 text
-  font-family: 'Skiff Sans Text', sans-serif;
+  font-family: var(--font-sans);
   font-size: 19px;
   line-height: 130%;
   color: ${(props) => getThemedColor('var(--text-secondary)', props.$forceTheme)};

--- a/src/components/InputField/InputField.styles.ts
+++ b/src/components/InputField/InputField.styles.ts
@@ -124,7 +124,7 @@ export const INPUT_FIELD_CSS = ({
   box-sizing: border-box;
 
   font-weight: ${$weight};
-  font-family: 'Skiff Sans Text', sans-serif;
+  font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
 
   caret-color: ${$caretColor ? getThemedColor(ICON_COLOR[$caretColor], $forceTheme) : 'var(--icon-link)'};

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -31,7 +31,7 @@ const TooltipWrap = styled(motion.div)<{ $stateX: number | null; $stateY: number
   border-radius: 8px;
   pointer-events: none;
   z-index: 9999999999;
-  font-family: 'Skiff Sans Text', sans-serif !important;
+  font-family: var(--font-sans) !important;
   font-weight: 470;
   -webkit-font-smoothing: antialiased !important;
   font-size: 11px !important;

--- a/src/components/Typography/Typography.styles.ts
+++ b/src/components/Typography/Typography.styles.ts
@@ -102,8 +102,8 @@ export const TEXT_CSS = css`
       font-weight: ${$weight};
       font-family: ${
         $mono
-          ? "Skiff Mono, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif"
-          : "Skiff Sans Text, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif"
+          ? "var(--font-mono)"
+          : "var(--font-sans)"
       };
       text-transform: ${$capitalize ? 'capitalize' : $uppercase ? 'uppercase' : ''};
       transition: ${$transition ?? ''};

--- a/src/theme/AppThemeProvider.tsx
+++ b/src/theme/AppThemeProvider.tsx
@@ -32,8 +32,13 @@ export const useTheme = () => useContext(ThemeContext);
 export const THEME_LOCAL_STORAGE_KEY = 'THEME_MODE';
 
 const GlobalStyles = createGlobalStyle`
+  :root {
+    --font-mono: Skiff Mono, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    --font-sans: Skiff Sans Text, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  }
+
   body {
-    font-family: 'Skiff Sans Text', sans-serif;
+    font-family: var(--font-sans);
     -webkit-font-smoothing: antialiased;
     font-smoothing: antialiased;
   }


### PR DESCRIPTION
Right now, the font-family declaration ends up getting duplicated, and it's very hard to change it out for users who prefers alternative fonts in order to read better, for example here's a uBlock filter I have that changes the font-family:

```
app.skiff.com##:is(body, .JiAak, .cVwhou, .eoLklO, .fAxOsz, .jHEUxp, .iLDdww, .hiApIQ, .kLJPYX, .iiHBHM, .dNbtdY, .ciBWbq, .fVBSEZ, .iCzuoM, .ibJRLq, .grYwly, .iTBNyT, .ibsFxk, .eUtQWs, .ZcwHI, .gxQMO, .buPNVE, .kvGqVe, .dkQatM, .imrrcE, .clnSRt, .bviZOY, .ggkUyS, .jDAZET, .idcaZw, .ifJZzO, .cuOBGO, .bnZNfP, .jwxRPZ, .cRQVWJ, .bBOBgx, .cwtIRm, .LQDHs, .IGRpV, .kPuktQ):style(font-family: sans-serif !important)
app.skiff.com##:is(.gCXAas, .cybZIz, .likDtR, .fMWDAN, .bBbWeX, .iExexu, .klRgxv):style(font-family: monospace !important)
```

As you can see, it's not very conducive, these class names changes at any time, making it very brittle. This pull request introduces the `--font-sans` and `--font-mono` CSS variables at `:root` so it can be changed easily.